### PR TITLE
Change dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     }
   ],
   "require": {
-    "symfony/yaml": "2.6.*",
-    "symfony/config": "2.6.*",
+    "symfony/yaml": ">=2.6.0",
+    "symfony/config": ">=2.6.0",
     "cache/cache": "dev-master"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     }
   ],
   "require": {
-    "symfony/yaml": ">=2.6.0",
-    "symfony/config": ">=2.6.0",
+    "symfony/yaml": ">=2.6 <=3.0",
+    "symfony/config": "^2.6.0",
     "cache/cache": "dev-master"
   },
   "require-dev": {


### PR DESCRIPTION
As we want to revert old integration tests in OMS we need to install DBUnit wich now is separate package from phpunit.
Installing DBUnit requires mathing dependencies.